### PR TITLE
Add test case for fulltext search

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,24 @@ docker run \
 
 ## Tested application functions:
 * Login
-* Open `person` module (first module under `address` module group)
-* Check if there's some data (wait for first record to appear)
-* Generate `Geburtstagsliste` report (Freemarker) for the first record
-* Generate `Mitarbeiterverzeichnis` report (Jasper) for the first record
+* Fulltext search
+  * Search for "Tocco AG Support" in fulltext search field in header bar
+  * Open item that contains "Tocco AG, Support" (should be a User)
+  * Check if User form loads with "Support" as firstname and "Tocco AG" as lastname
+  * Check if default display in panel with open entities is "Tocco AG, Support"
+* Reports
+  * Open `person` module (first module under `address` module group)
+  * Check if there's some data (wait for first record to appear)
+  * Generate `Geburtstagsliste` report (Freemarker) for the first record
+  * Generate `Mitarbeiterverzeichnis` report (Jasper) for the first record
 
 ## Prerequisites and assumptions
 * The `person` module has to be the first module in the `address` module group
 * The reports `Geburtstagsliste` and `Mitarbeiterverzeichnis` report have to be available
 * The configured login must exist on the configured installation
 * The interface language of the login must be german
-* The login requires at least the role `userguest` to be allowed to test the functionality described above
+* The login requires the role `userguest` (**only** this role) to be allowed to test the functionality described above
+* There must exist a User entity called "Tocco AG, Support" (firstname "Support", lastname "Tocco AG")
 
 ## Known issues
 

--- a/cypress/integration/fulltext_search.spec.js
+++ b/cypress/integration/fulltext_search.spec.js
@@ -1,0 +1,22 @@
+context('Fulltext search', () => {
+
+    before(() => {
+        cy.visit(`https://${Cypress.env('host')}/tocco`)
+        cy.loginUi()
+    })
+
+    it('should find Tocco person in fulltext search field', () => {
+        cy.get('.admin-header input[type=text].full-find').type('Tocco AG Support')
+
+        cy.get('.x-combo-list .search-item', {
+            timeout: 120000 // it can take quite some time until the search results appear
+        }).contains('Tocco AG, Support').click()
+
+        // form values
+        cy.get('.firstname-value').contains('Support')
+        cy.get('.lastname-value').contains('Tocco AG')
+
+        // default display in open panel
+        cy.get('#openPanel_1').contains('Tocco AG, Support')
+    })
+})

--- a/cypress/integration/reports.js
+++ b/cypress/integration/reports.js
@@ -1,28 +1,12 @@
-context('Test', () => {
+context('Reports', () => {
 
     const tabHeader = '.x-tab-panel-header ul'
     const firstTab = '.x-tab-panel-body > div:nth-child(2)'
 
     before(() => {
         cy.visit(`https://${Cypress.env('host')}/tocco`)
-        cy.getCookie('nice_auth').then(cookie => {
-            if (!cookie) {
-                login()
-            }
-        })
+        cy.loginUi()
     })
-
-    beforeEach(function () {
-        Cypress.Cookies.preserveOnce('nice_auth')
-    })
-
-    const login = () => {
-        cy.get('input[name=user]').type(Cypress.env('username'))
-        cy.get('input[name=password]').type(Cypress.env('password'), {
-            log: false
-        })
-        cy.get('button[type=submit]').click()
-    }
 
     const generatePersonReport = report => {
         cy.get(tabHeader).contains('Home').click()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,19 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+const login = () => {
+    cy.get('input[name=user]').type(Cypress.env('username'))
+    cy.get('input[name=password]').type(Cypress.env('password'), {
+        log: false
+    })
+    cy.get('button[type=submit]').click()
+}
+
+Cypress.Commands.add("loginUi", () => {
+    cy.getCookie('nice_auth').then(cookie => {
+        if (!cookie) {
+            login()
+        }
+    })
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -13,8 +13,8 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
-// Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
+Cypress.Cookies.defaults({
+    whitelist: 'nice_auth'
+})


### PR DESCRIPTION
- Should find Tocco person in the fulltext search field in the app bar
- Opens the person
- Checks if the (readonly) detail form has been loaded and the
  firstname is "Support" and the lastname is "Tocco AG"
- Checks if the default display "Tocco AG, Support" is correctly
  displayed in the panel with the open entities